### PR TITLE
Don't convert track art unless asked to

### DIFF
--- a/RNiTunes/RNiTunes.m
+++ b/RNiTunes/RNiTunes.m
@@ -204,14 +204,13 @@ RCT_EXPORT_METHOD(getTracks:(NSDictionary *)params successCallback:(RCTResponseS
         }
         if (artwork == nil) {
             artworkBase64 = @"";
-        } else {
-            UIImage *image = [artwork imageWithSize:CGSizeMake(480, 480)];
-            artworkBase64 = [NSString stringWithFormat:@"%@%@", @"data:image/jpeg;base64,", [self imageToNSString:image]];
         }
 
         NSDictionary *songDictionary = [NSMutableDictionary dictionary];
 
         if (fields == nil) {
+            UIImage *image = [artwork imageWithSize:CGSizeMake(480, 480)];
+            artworkBase64 = [NSString stringWithFormat:@"%@%@", @"data:image/jpeg;base64,", [self imageToNSString:image]];
             songDictionary = @{
               @"albumTitle": albumTitle,
               @"albumArtist": albumArtist,


### PR DESCRIPTION
Previously in `getTracks`, we were encoding the artwork no matter what, even if we didn't include the artwork in the `fields` object param. This task is extremely expensive.

Here we move the task of encoding the image into section which checks the fields first. Now, we will only include and encode the image if no fields are passed or if the artwork field is explicitly passed.